### PR TITLE
Fixed H265 resolution issue

### DIFF
--- a/drivers/amlogic/amports/vh265.c
+++ b/drivers/amlogic/amports/vh265.c
@@ -4754,6 +4754,9 @@ static int prepare_display_buf(struct hevc_state_s *hevc, struct PIC_s *pic)
 		vf->compWidth = pic->width;
 		vf->compHeight = pic->height;
 
+		if (vf->compHeight == 1088)
+			vf->compHeight = 1080;
+
 		switch (hevc->bit_depth_luma) {
 		case 9:
 			vf->bitdepth = BITDEPTH_Y9;


### PR DESCRIPTION
Applied the same fix as already was in vh264.c: 1088 height is now truncated to 1080 what is a correct behavior for this format. Proven to be working with moonlight-embedded.